### PR TITLE
simplify client

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ client = ToucanClient('https://api.some.project.com/my_small_app', auth=auth)
 etl_config = client.config.etl.get()  # -> GET 'https://api.some.project.com/config/etl'
 
 # Example: add staging option
-params = {'stage': 'staging'}
-client.config.etl.get(params=params)  # -> GET 'https://api.some.project.com/config/etl?stage=staging'
+client.config.etl.get(stage='staging')  # -> GET 'https://api.some.project.com/config/etl?stage=staging'
 
 # Example: send a post request with some json data
 json = {'DATA_SOURCE': ['example']}

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ client = ToucanClient('https://api.some.project.com/my_small_app', auth=auth)
 etl_config = client.config.etl.get()  # -> GET 'https://api.some.project.com/config/etl'
 
 # Example: add staging option
-client.stage = 'staging'  # -> GET 'https://api.some.project.com/config/etl?stage=staging'
+params = {'stage': 'staging'}
+client.config.etl.get(params=params)  # -> GET 'https://api.some.project.com/config/etl?stage=staging'
 
 # Example: send a post request with some json data
-client.json = {'DATA_SOURCE': ['example']}
-response = client.config.etl.put()
+json = {'DATA_SOURCE': ['example']}
+response = client.config.etl.put(json=json)
 # response.status_code equals 200 if everything went well
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = toucan_client
 description = Toucan API client
 author = Toucan Toco
 url = https://github.com/ToucanToco/toucan-client
-version = 0.0.7
+version = 1.0.0
 license = BSD
 classifiers=
     Intended Audience :: Developers

--- a/tests/test_client_toucanclient.py
+++ b/tests/test_client_toucanclient.py
@@ -4,5 +4,13 @@ from toucan_client.client import ToucanClient
 def test_get(mocker):
     mock_get = mocker.patch('requests.get')
     small_app = ToucanClient('fake.route/my-small-app')
+
     small_app.config.etl.get()
     mock_get.assert_called_once_with('fake.route/my-small-app/config/etl')
+    mock_get.reset_mock()
+
+    small_app.config.etl.get(stage='staging')
+    mock_get.assert_called_once_with(
+        'fake.route/my-small-app/config/etl',
+        params={'stage': 'staging'}
+    )

--- a/tests/test_client_toucanclient.py
+++ b/tests/test_client_toucanclient.py
@@ -1,50 +1,8 @@
-import pytest
-
 from toucan_client.client import ToucanClient
 
-SMALL_APP_NAME = 'my-small-app'
 
-BASE_ROUTE = 'fake.route/my-small-app'
-BASE_ROUTE_2 = 'fake.route/my-small-app/'
-
-
-@pytest.fixture(name='small_app', scope='function')
-def gen_small_app():
-    return ToucanClient(BASE_ROUTE)
-
-
-def test_simple_get(small_app):
-    """It should build the right URL"""
-    _ = small_app.config.etl.get
-    assert small_app.method == 'get'
-    assert small_app.route == '{}/config/etl'.format(BASE_ROUTE)
-
-
-def test_simple_get_with_baseroute_2():
-    small_app = ToucanClient(BASE_ROUTE_2)
-    _ = small_app.config.etl.get
-    assert small_app.method == 'get'
-    assert small_app.route == '{}/config/etl'.format(BASE_ROUTE)
-
-
-def test_simple_get_with_stage(small_app):
-    """It should build the right URL (with staging stage)"""
-    small_app.stage = 'staging'
-    _ = small_app.config.etl.get
-    assert small_app.method == 'get'
-    assert small_app.route == '{}/config/etl?stage=staging'.format(BASE_ROUTE)
-
-
-def test_call(small_app, mocker):
-    mock_getattr = mocker.patch('requests.get')
-    mock_getattr.return_value = 1
-    mock_getattr.return_value = 1
-    res = small_app.config.etl.get()
-    assert res == 1
-
-
-def test_kwargs(small_app):
-    """It should add kwargs"""
-    small_app.best_character = 'Ryu'
-    _ = small_app.config.etl.get
-    assert small_app.kwargs == {'best_character': 'Ryu'}
+def test_get(mocker):
+    mock_get = mocker.patch('requests.get')
+    small_app = ToucanClient('fake.route/my-small-app')
+    small_app.config.etl.get()
+    mock_get.assert_called_once_with('fake.route/my-small-app/config/etl')

--- a/toucan_client/client.py
+++ b/toucan_client/client.py
@@ -1,16 +1,9 @@
-import logging
-
 import requests
-
-logger = logging.getLogger(__name__)
 
 
 class ToucanClient:
     """
-    Small client for sending request to a Toucan Toco back end.
-    The constructor's mandatory parameter is the API base url. One can pass
-    a small app name or a list of small app names, a token or an auth object
-    for authentication.
+    Small client for sending requests to a Toucan Toco backend.
 
     >>> # Example: Fetch etl config
     >>> client = ToucanClient('https://api.some.project.com')
@@ -22,53 +15,21 @@ class ToucanClient:
     >>> # response.status_code equals 200 if everything went well
     """
 
-    EXTRACTION_CACHE_PATH = 'extraction_cache'
+    def __init__(self, base_route, _path=None, **kwargs):
+        self._base_route = base_route.strip().rstrip('/')
+        self._requests_kwargs = kwargs
+        self._path = tuple(_path) if _path else ()
 
-    def __init__(self, base_route, **kwargs):
-        # type: (str) -> SmallAppRequester
-        self.__dict__['_path'] = []
-        self.__dict__['kwargs'] = kwargs
-        self.__dict__['stage'] = ''
-        self.__dict__['_dfs'] = None
-        self.__dict__['_cache_path'] = None
-
-        self.__dict__['base_route'] = base_route
-        if base_route.endswith('/'):
-            self.__dict__['base_route'] = base_route[:-1]
-
-    @property
-    def method(self):
-        # type: () -> str
-        return self._path[-1]
-
-    @property
-    def options(self):
-        # type: () -> str
-        if self.stage:
-            return '?stage={}'.format(self.stage)
-        return ''
-
-    @property
-    def route(self):
-        # type: () -> str
-        route = '/'.join([self.base_route] + self._path[:-1])
-        route += self.options
-
-        self.__dict__['_path'] = []
-        return route
+    def __getitem__(self, key):
+        new_path = self._path + (key,)
+        return ToucanClient(self._base_route, new_path, **self._requests_kwargs)
 
     def __getattr__(self, key):
-        self._path.append(key)
-        return self
+        return self[key]  # forward to __getitem__
 
-    def __setattr__(self, key, value):
-        if key == 'stage':
-            self.__dict__['stage'] = value
-        else:
-            self.kwargs[key] = value
-
-    def __call__(self):
-        # type: () -> requests.Response
-        method, route = self.method, self.route
-        func = getattr(requests, method)
-        return func(route, **self.kwargs)
+    def __call__(self, **kwargs):
+        method = self._path[-1]
+        method_func = getattr(requests, method)
+        url = '/'.join((self._base_route,) + self._path[:-1])
+        requests_kwargs = {**self._requests_kwargs, **kwargs}
+        return method_func(url, **requests_kwargs)

--- a/toucan_client/client.py
+++ b/toucan_client/client.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import requests
 
 
@@ -31,5 +33,6 @@ class ToucanClient:
         method = self._path[-1]
         method_func = getattr(requests, method)
         url = '/'.join((self._base_route,) + self._path[:-1])
-        requests_kwargs = {**self._requests_kwargs, **kwargs}
+        requests_kwargs = deepcopy(self._requests_kwargs)
+        requests_kwargs.update(kwargs)
         return method_func(url, **requests_kwargs)

--- a/toucan_client/client.py
+++ b/toucan_client/client.py
@@ -3,6 +3,17 @@ from copy import deepcopy
 import requests
 
 
+def build_requests_kwargs(kwargs, extra_kwargs):
+    requests_kwargs = deepcopy(kwargs)
+    requests_kwargs.update(extra_kwargs)
+
+    if "stage" in requests_kwargs:
+        requests_kwargs['params'] = requests_kwargs.get('params', {})
+        requests_kwargs['params'].update({'stage': requests_kwargs.pop('stage')})
+
+    return requests_kwargs
+
+
 class ToucanClient:
     """
     Small client for sending requests to a Toucan Toco backend.
@@ -33,6 +44,5 @@ class ToucanClient:
         method = self._path[-1]
         method_func = getattr(requests, method)
         url = '/'.join((self._base_route,) + self._path[:-1])
-        requests_kwargs = deepcopy(self._requests_kwargs)
-        requests_kwargs.update(kwargs)
+        requests_kwargs = build_requests_kwargs(self._requests_kwargs, kwargs)
         return method_func(url, **requests_kwargs)


### PR DESCRIPTION
- Switch from a mutable object to an immutable one (prevent weird behavior)
- Allow to pass requests kwargs in __call__
- Add a shortcut for stage=staging
- Bump version number (todo when merged → `make clean build upload`)